### PR TITLE
Remove team member publications because they are not filtered properly

### DIFF
--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -32,14 +32,13 @@ layout: default
   research/?search={% for alias in aliases %}"{{ alias }}" {% endfor %}
 {%- endcapture %}
 
-<!--
 <p class="center">
   <a href="{{ search | relative_url | uri_escape }}">
     Search for {{ page.name | default: page.title }}'s papers on the Research page
   </a>
 </p>
--->
 
+<!--
 <h2>Publications</h2>
 
 Note: this list currently includes all publications from this team member, possibly including work published while they were in previous labs.
@@ -57,6 +56,7 @@ member: {{ page.member }}
 {% capture search -%}
   blog/?search={{ page.name }}
 {%- endcapture %}
+-->
 
 <!--
 <p class="center">

--- a/_members/christian-blumenscheit.md
+++ b/_members/christian-blumenscheit.md
@@ -3,6 +3,8 @@ name: Christian Blumenscheit
 member: christian-blumenscheit
 image: images/members/christian-blumenscheit.jpg
 role: postdoc
+aliases:
+  - Christian Blumenscheit
 links:
   orcid: 0000-0001-8987-2355
 ---

--- a/_members/david-fischer.md
+++ b/_members/david-fischer.md
@@ -5,6 +5,7 @@ image: images/members/david-fischer.jpg
 role: undergrad
 aliases:
   - David Stephan Fischer
+  - David Fischer
 links:
   orcid: 0009-0002-1313-7439
   github: fischer-hub

--- a/_members/hugues-richard.md
+++ b/_members/hugues-richard.md
@@ -5,6 +5,7 @@ image: images/members/hugues-richard.jpg
 role: senior-scientist
 description: Senior Scientist/Project PI
 aliases:
+  - Hugues Richard
   - H Richard
   - H. Richard
 links:

--- a/_members/martin-hoelzer.md
+++ b/_members/martin-hoelzer.md
@@ -5,6 +5,7 @@ image: images/members/martin-hoelzer.jpg
 role: team-lead
 description: Team Lead/Group PI
 aliases:
+  - Martin Hölzer
   - Martin Hoelzer
   - M. Hoelzer
 links:


### PR DESCRIPTION
Temporarily remove the list of publications from each team members' page because the search is broken. This was leading to all publications being listed on every member's page.

